### PR TITLE
Feature/explicit selectors

### DIFF
--- a/importer.js
+++ b/importer.js
@@ -64,7 +64,7 @@ function parseImportString(string) {
 
 function getSelectorAndDeclarations(string) {
   let [selector, declarations] = string.split(/[{}]/);
-  selector = selector.trim();
+  selector = csstree.translate(csstree.parse(selector, { context: 'selectorList' }));
 
   if (declarations) {
     declarations = declarations.split(',').map(val => val.trim());

--- a/importer.js
+++ b/importer.js
@@ -51,7 +51,7 @@ function parseImportString(string) {
     let selectorMatches = definitionString.match(/{([\s\S]+)}/);
 
     if (selectorMatches) {
-      let definition = selectorMatches[1].split(/,(?![^{]*})/).map(
+      let definition = selectorMatches[1].match(/.+?}/g).map(
         getSelectorAndDeclarations
       );
 


### PR DESCRIPTION
This PR changes definitions from 
`remove { a, h1 { ... } }` to `remove { a {} h1 { ...} }`.

It also compares the selectors now in full. This means, that we can just remove declarations from a rule, without duplicating it.  
(For now at least, until we possibly introduce single-selector-out-of-list removal)

fixes #2 